### PR TITLE
wscsv not disabled in upstream source anymore

### DIFF
--- a/scripts/Disable Services.ps1
+++ b/scripts/Disable Services.ps1
@@ -16,7 +16,7 @@ $services = @(
     "WbioSrvc"                                 # Windows Biometric Service (required for Fingerprint reader / facial detection)
     #"WlanSvc"                                 # WLAN AutoConfig
     "WMPNetworkSvc"                            # Windows Media Player Network Sharing Service
-    "wscsvc"                                   # Windows Security Center Service
+    #"wscsvc"                                   # Windows Security Center Service
     #"WSearch"                                 # Windows Search
     "XblAuthManager"                           # Xbox Live Auth Manager
     "XblGameSave"                              # Xbox Live Game Save Service


### PR DESCRIPTION
The original source of this file has commented out WSCSVC for some reason, perhaps this project should do the same...

As per https://github.com/W4RH4WK/Debloat-Windows-10/blob/master/scripts/disable-services.ps1
